### PR TITLE
新增 Codex 登录模型提供方模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@
 - `API Key`
 - `模型`
 
+如果要使用 Codex/ChatGPT 登录认证，请把认证方式选为 `Codex login`，`供应商格式` 保持 `OpenAI Responses API`，Base URL 使用 `https://chatgpt.com/backend-api/codex`。本机先运行 `codex login`，然后把 `~/.codex/auth.json` 内容或 access token 粘贴到凭据输入框。
+
 保存并应用后，关闭并重新打开一次侧边栏即可生效。
 
 ### 3. 推荐设置

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,6 +58,8 @@ Open the extension options page and go to `Model provider` in the left menu. Cre
 - `API Key`
 - `Model`
 
+To use Codex/ChatGPT login credentials, choose `Codex login` as the authentication mode, keep `Provider format` on `OpenAI Responses API`, and use `https://chatgpt.com/backend-api/codex` as the base URL. Run `codex login` locally, then paste the contents of `~/.codex/auth.json` or the access token into the credential field.
+
 After saving and applying the configuration, close and reopen the sidebar once to make it take effect.
 
 ### 3. Recommended setting

--- a/assets/sidepanel-BoLm9pmH.js
+++ b/assets/sidepanel-BoLm9pmH.js
@@ -87498,14 +87498,12 @@ async function lQ(e, t) {
   }
 }
 async function cQ(e, t, n = {}) {
+  const s = __cpExtractSessionDisplayText(e?.content, __CP_CHAT_SESSION_TEXT_LIMIT);
   try {
-    const s = __cpExtractSessionDisplayText(e?.content, __CP_CHAT_SESSION_TEXT_LIMIT);
     if (!s || s.trim() === "") {
       return "";
     }
-    const r = function (e) {
-      return `<conversation>\n\n${e}\n\n</conversation>\n\nThink about it, then suggest a title based on the first message, putting it between <title> tags.`;
-    }(s);
+    const r = __cpBuildTaskStyleGroupTitlePrompt(s, n);
     const i = [{
       role: "user",
       content: r
@@ -87514,7 +87512,7 @@ async function cQ(e, t, n = {}) {
       role: "assistant",
       content: "Here is a clear, concise title for this browser automation conversation:\n\n<title>"
     });
-    return function (e) {
+    const o = function (e) {
       const t = e => {
         const t = String(e || "").replace(/<\/?title>/gi, " ").replace(/<[^>]*>/g, " ").replace(/[\u0000-\u001f\u007f]/g, " ").replace(/\s+/g, " ").trim();
         return t && t.toLowerCase() !== "title" ? __cpTrimSessionText(__cpStripSessionDisplayArtifacts(t), __CP_GROUP_TITLE_LIMIT) : "";
@@ -87539,8 +87537,9 @@ async function cQ(e, t, n = {}) {
       system: "Act as an accurate and concise title generator for browser automation conversations.\nGenerate a <title> based on the first message in the conversation.\n\nBasic tips:\n- Focus on the main browser task or action being requested\n- Identify the key website, action, or goal from the message\n- The conversation is a request to an AI assistant for browser automation. Avoid using \"Help\", \"Assistance\", \"Request\" in the title.\n- Be informative and specific to create a unique, distinctive title\n- Keep it short and concise - typically 2-4 words\n- Start with the most identifying/important word first\n- Think like an editor - what will be most compelling and informative for identifying this conversation\n- If you are unsure what the task is about, just create an empty <title></title>\n\nExamples of good titles for browser automation tasks:\n- <title>Draft email response</title>\n- <title>Grocery shopping</title>\n- <title>Paris flight search</title>",
       modelClass: "small_fast"
     }));
-  } catch (s) {
-    return "";
+    return o || __cpBuildTaskStyleGroupTitleFallback(s, n);
+  } catch (r) {
+    return __cpBuildTaskStyleGroupTitleFallback(s, n);
   }
 }
 function __cpEscapeXmlText(e) {

--- a/custom-provider-models.js
+++ b/custom-provider-models.js
@@ -4,6 +4,14 @@
   const OPENAI_CHAT_FORMAT = "openai_chat";
   const OPENAI_RESPONSES_FORMAT = "openai_responses";
   const DEFAULT_FORMAT = ANTHROPIC_FORMAT;
+  const AUTH_MODE_API_KEY = "api_key";
+  const AUTH_MODE_CODEX = "codex";
+  const DEFAULT_AUTH_MODE = AUTH_MODE_API_KEY;
+  const CODEX_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex";
+  const CODEX_REFRESH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+  const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+  const CODEX_MODELS_CLIENT_VERSION = "0.125.0-alpha.3";
+  const CODEX_ACCESS_TOKEN_REFRESH_SKEW_MS = 120000;
   const DEFAULT_CONTEXT_WINDOW = 200000;
   const DEFAULT_MAX_OUTPUT_TOKENS = 10000;
   const MIN_CONTEXT_WINDOW = 20000;
@@ -39,6 +47,20 @@
   const FETCHED_MODELS_CACHE_LIMIT = 24;
   const HEALTH_CHECK_PROMPT = "Reply with OK only.";
   const HEALTH_CHECK_MAX_TOKENS = 64;
+  function normalizeAuthMode(value) {
+    const mode = String(value || "")
+      .trim()
+      .toLowerCase();
+    if (
+      mode === AUTH_MODE_CODEX ||
+      mode === "chatgpt" ||
+      mode === "codex_login" ||
+      mode === "codex-chatgpt"
+    ) {
+      return AUTH_MODE_CODEX;
+    }
+    return AUTH_MODE_API_KEY;
+  }
   function normalizeFormat(value) {
     const format = String(value || "")
       .trim()
@@ -53,6 +75,124 @@
       return OPENAI_RESPONSES_FORMAT;
     }
     return DEFAULT_FORMAT;
+  }
+  function parseJsonObject(value) {
+    const text = String(value || "").trim();
+    if (!text || !/^[\[{]/.test(text)) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(text);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  function decodeBase64UrlJson(value) {
+    const text = String(value || "").trim();
+    if (!text) {
+      return null;
+    }
+    try {
+      const base64 = text.replace(/-/g, "+").replace(/_/g, "/");
+      const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+      const decoded =
+        typeof globalThis.atob === "function" ? globalThis.atob(padded) : "";
+      if (!decoded) {
+        return null;
+      }
+      const jsonText = decodeURIComponent(
+        decoded
+          .split("")
+          .map(function (char) {
+            return "%" + char.charCodeAt(0).toString(16).padStart(2, "0");
+          })
+          .join(""),
+      );
+      const parsed = JSON.parse(jsonText);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  function decodeJwtPayload(token) {
+    const parts = String(token || "").split(".");
+    if (parts.length < 2) {
+      return null;
+    }
+    return decodeBase64UrlJson(parts[1]);
+  }
+  function extractCodexAccountIdFromPayload(payload) {
+    if (!payload || typeof payload !== "object") {
+      return "";
+    }
+    const directCandidates = [
+      payload.account_id,
+      payload.chatgpt_account_id,
+      payload["chatgpt_account_id"],
+    ];
+    for (const candidate of directCandidates) {
+      const value = String(candidate || "").trim();
+      if (value) {
+        return value;
+      }
+    }
+    const authClaim = payload["https://api.openai.com/auth"];
+    if (authClaim && typeof authClaim === "object") {
+      return extractCodexAccountIdFromPayload(authClaim);
+    }
+    return "";
+  }
+  function extractCodexAccountIdFromToken(token) {
+    return extractCodexAccountIdFromPayload(decodeJwtPayload(token));
+  }
+  function normalizeCodexAuthPayload(rawApiKey, source) {
+    const raw = String(rawApiKey || "").trim();
+    const parsed = parseJsonObject(raw);
+    const tokenSource =
+      parsed?.tokens && typeof parsed.tokens === "object"
+        ? parsed.tokens
+        : parsed && typeof parsed === "object"
+          ? parsed
+          : {};
+    const accessToken = String(
+      tokenSource.access_token || tokenSource.accessToken || raw,
+    ).trim();
+    const refreshToken = String(
+      tokenSource.refresh_token ||
+        tokenSource.refreshToken ||
+        source?.codexRefreshToken ||
+        source?.refreshToken ||
+        "",
+    ).trim();
+    const idToken = String(
+      tokenSource.id_token || tokenSource.idToken || source?.codexIdToken || "",
+    ).trim();
+    const accountId = String(
+      tokenSource.account_id ||
+        tokenSource.accountId ||
+        source?.codexAccountId ||
+        source?.accountId ||
+        extractCodexAccountIdFromToken(idToken) ||
+        extractCodexAccountIdFromToken(accessToken) ||
+        "",
+    ).trim();
+    const lastRefresh = String(
+      parsed?.last_refresh ||
+        parsed?.lastRefresh ||
+        source?.codexLastRefresh ||
+        source?.lastRefresh ||
+        "",
+    ).trim();
+    return {
+      apiKey: accessToken,
+      codexAccountId: accountId,
+      codexRefreshToken: refreshToken,
+      codexLastRefresh: lastRefresh,
+    };
+  }
+  function isCodexAuthConfig(config) {
+    return normalizeAuthMode(config?.authMode) === AUTH_MODE_CODEX;
   }
   function inferFormat(source) {
     const explicitFormat = String(source?.format || "").trim();
@@ -107,13 +247,32 @@
   }
   function normalizeConfig(raw, fallbackEnabled) {
     const source = raw && typeof raw === "object" ? raw : {};
+    const authMode = normalizeAuthMode(source.authMode);
+    const codexAuth =
+      authMode === AUTH_MODE_CODEX
+        ? normalizeCodexAuthPayload(source.apiKey, source)
+        : null;
     return {
+      id: String(source.id || "").trim(),
       name: String(source.name || "").trim(),
-      format: inferFormat(source),
-      baseUrl: String(source.baseUrl || "")
+      authMode,
+      format:
+        authMode === AUTH_MODE_CODEX ? OPENAI_RESPONSES_FORMAT : inferFormat(source),
+      baseUrl: String(
+        source.baseUrl || (authMode === AUTH_MODE_CODEX ? CODEX_DEFAULT_BASE_URL : ""),
+      )
         .trim()
         .replace(/\/+$/, ""),
-      apiKey: String(source.apiKey || "").trim(),
+      apiKey:
+        authMode === AUTH_MODE_CODEX
+          ? codexAuth.apiKey
+          : String(source.apiKey || "").trim(),
+      codexAccountId:
+        authMode === AUTH_MODE_CODEX ? codexAuth.codexAccountId : "",
+      codexRefreshToken:
+        authMode === AUTH_MODE_CODEX ? codexAuth.codexRefreshToken : "",
+      codexLastRefresh:
+        authMode === AUTH_MODE_CODEX ? codexAuth.codexLastRefresh : "",
       defaultModel: String(source.defaultModel || "").trim(),
       fastModel: String(
         source.fastModel || source.small_fast_model || "",
@@ -138,9 +297,13 @@
   function createEmptyConfig() {
     return {
       name: "",
+      authMode: DEFAULT_AUTH_MODE,
       format: DEFAULT_FORMAT,
       baseUrl: "",
       apiKey: "",
+      codexAccountId: "",
+      codexRefreshToken: "",
+      codexLastRefresh: "",
       defaultModel: "",
       fastModel: "",
       reasoningEffort: "medium",
@@ -151,6 +314,20 @@
   }
   function joinUrl(baseUrl, suffix) {
     return `${String(baseUrl || "").replace(/\/+$/, "")}/${String(suffix || "").replace(/^\/+/, "")}`;
+  }
+  function buildModelsUrl(config) {
+    const next = normalizeConfig(config);
+    const url = joinUrl(next.baseUrl, "models");
+    if (!isCodexAuthConfig(next)) {
+      return url;
+    }
+    const separator = url.includes("?") ? "&" : "?";
+    return (
+      url +
+      separator +
+      "client_version=" +
+      encodeURIComponent(CODEX_MODELS_CLIENT_VERSION)
+    );
   }
   function buildRequestUrl(baseUrl, format) {
     const normalizedBaseUrl = String(baseUrl || "")
@@ -311,9 +488,15 @@
     if (!next.baseUrl || !next.apiKey) {
       return "";
     }
+    const credentialKey =
+      next.authMode === AUTH_MODE_CODEX
+        ? next.codexAccountId || next.codexRefreshToken || next.apiKey
+        : next.apiKey;
     return (
       "provider_" +
-      hashProviderCacheKey([next.format, next.baseUrl, next.apiKey].join("\n"))
+      hashProviderCacheKey(
+        [next.authMode, next.format, next.baseUrl, credentialKey].join("\n"),
+      )
     );
   }
   function normalizeFetchedModelsCache(raw) {
@@ -392,9 +575,13 @@
     return {
       id: String(raw?.id || "").trim() || createProfileId(),
       name: String(raw?.name || "").trim(),
+      authMode: config.authMode,
       format: config.format,
       baseUrl: config.baseUrl,
       apiKey: config.apiKey,
+      codexAccountId: config.codexAccountId,
+      codexRefreshToken: config.codexRefreshToken,
+      codexLastRefresh: config.codexLastRefresh,
       defaultModel: config.defaultModel,
       fastModel: config.fastModel,
       reasoningEffort: config.reasoningEffort,
@@ -415,6 +602,7 @@
     const config = normalizeConfig(raw);
     return !!(
       config.name ||
+      config.authMode !== DEFAULT_AUTH_MODE ||
       config.baseUrl ||
       config.apiKey ||
       config.defaultModel ||
@@ -428,11 +616,26 @@
     }
     return {
       name: String(profile.name || "").trim(),
-      format: normalizeFormat(profile.format),
-      baseUrl: String(profile.baseUrl || "")
+      authMode: normalizeAuthMode(profile.authMode),
+      format: isCodexAuthConfig(profile)
+        ? OPENAI_RESPONSES_FORMAT
+        : normalizeFormat(profile.format),
+      baseUrl: String(
+        profile.baseUrl ||
+          (isCodexAuthConfig(profile) ? CODEX_DEFAULT_BASE_URL : ""),
+      )
         .trim()
         .replace(/\/+$/, ""),
       apiKey: String(profile.apiKey || "").trim(),
+      codexAccountId: isCodexAuthConfig(profile)
+        ? String(profile.codexAccountId || "").trim()
+        : "",
+      codexRefreshToken: isCodexAuthConfig(profile)
+        ? String(profile.codexRefreshToken || "").trim()
+        : "",
+      codexLastRefresh: isCodexAuthConfig(profile)
+        ? String(profile.codexLastRefresh || "").trim()
+        : "",
       defaultModel: String(profile.defaultModel || "").trim(),
       fastModel: String(profile.fastModel || "").trim(),
       reasoningEffort: normalizeReasoningEffort(profile.reasoningEffort),
@@ -957,19 +1160,216 @@
       };
     }
   }
+  function parseServerSentEventText(text) {
+    const events = [];
+    const blocks = String(text || "").split(/\r?\n\r?\n+/);
+    for (const block of blocks) {
+      const dataLines = [];
+      for (const line of block.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(":")) {
+          continue;
+        }
+        if (trimmed.startsWith("data:")) {
+          dataLines.push(trimmed.slice(5).trimStart());
+        }
+      }
+      const data = dataLines.join("\n").trim();
+      if (!data || data === "[DONE]") {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(data);
+        if (parsed && typeof parsed === "object") {
+          events.push(parsed);
+        }
+      } catch {
+        events.push({
+          message: data,
+        });
+      }
+    }
+    return events;
+  }
+  function extractOutputTextFromSseEvent(event) {
+    if (!event || typeof event !== "object") {
+      return "";
+    }
+    const type = String(event.type || "").trim();
+    if (
+      type === "response.output_text.delta" &&
+      typeof event.delta === "string"
+    ) {
+      return event.delta;
+    }
+    if (
+      type === "response.output_text.delta" &&
+      typeof event.text === "string"
+    ) {
+      return event.text;
+    }
+    if (typeof event.delta === "string") {
+      return event.delta;
+    }
+    if (typeof event.delta?.text === "string") {
+      return event.delta.text;
+    }
+    if (Array.isArray(event.choices)) {
+      return event.choices
+        .map(function (choice) {
+          return String(choice?.delta?.content || "").trim();
+        })
+        .filter(Boolean)
+        .join("");
+    }
+    return "";
+  }
+  function extractDoneTextFromSseEvent(event) {
+    if (!event || typeof event !== "object") {
+      return "";
+    }
+    if (
+      String(event.type || "") === "response.output_text.done" &&
+      typeof event.text === "string"
+    ) {
+      return event.text;
+    }
+    return "";
+  }
+  function sseEventsToProbePayload(events) {
+    const list = Array.isArray(events) ? events : [];
+    const deltaText = list.map(extractOutputTextFromSseEvent).join("").trim();
+    const doneText = deltaText
+      ? ""
+      : list.map(extractDoneTextFromSseEvent).filter(Boolean).join("").trim();
+    const outputText = deltaText || doneText;
+    return {
+      output_text: outputText,
+      output: list,
+      event_count: list.length,
+    };
+  }
+  async function parseProviderPayload(response) {
+    const text = await response.text();
+    if (!text) {
+      return {};
+    }
+    const contentType = String(response.headers?.get?.("content-type") || "");
+    if (contentType.includes("text/event-stream") || /^data:/m.test(text)) {
+      const events = parseServerSentEventText(text);
+      if (events.length) {
+        return sseEventsToProbePayload(events);
+      }
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      return {
+        message: text,
+      };
+    }
+  }
+  function getJwtExpiryMs(token) {
+    const payload = decodeJwtPayload(token);
+    const seconds = Number(payload?.exp);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return 0;
+    }
+    return seconds * 1000;
+  }
+  function shouldRefreshCodexAccessToken(config, nowMs) {
+    const next = normalizeConfig(config);
+    if (!isCodexAuthConfig(next) || !next.codexRefreshToken) {
+      return false;
+    }
+    const expiryMs = getJwtExpiryMs(next.apiKey);
+    if (!expiryMs) {
+      return false;
+    }
+    const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+    return expiryMs <= now + CODEX_ACCESS_TOKEN_REFRESH_SKEW_MS;
+  }
+  async function refreshCodexAuthForConfig(config, options) {
+    const settings = options && typeof options === "object" ? options : {};
+    const next = normalizeConfig(config);
+    if (!isCodexAuthConfig(next) || !next.codexRefreshToken) {
+      return next;
+    }
+    if (
+      !settings.force &&
+      !shouldRefreshCodexAccessToken(next, settings.nowMs)
+    ) {
+      return next;
+    }
+    const fetchImpl = settings.fetchImpl || globalThis.fetch;
+    if (typeof fetchImpl !== "function") {
+      return next;
+    }
+    const response = await fetchImpl(CODEX_REFRESH_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        client_id: CODEX_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: next.codexRefreshToken,
+      }),
+      signal: settings.signal,
+    });
+    const payload = await parseJsonSafe(response);
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(payload, `Codex 认证刷新失败（${response.status}）`),
+      );
+    }
+    const refreshed = normalizeConfig({
+      ...next,
+      apiKey: String(payload.access_token || next.apiKey).trim(),
+      codexRefreshToken: String(
+        payload.refresh_token || next.codexRefreshToken,
+      ).trim(),
+      codexAccountId:
+        extractCodexAccountIdFromToken(payload.id_token) ||
+        extractCodexAccountIdFromToken(payload.access_token) ||
+        next.codexAccountId,
+      codexLastRefresh: new Date().toISOString(),
+    });
+    const profileId = String(settings.profileId || next.id || "").trim();
+    if (settings.persist !== false && profileId) {
+      await saveProviderProfile(refreshed, {
+        profileId,
+        storageArea: settings.storageArea,
+        activateOnSave: true,
+      });
+    }
+    return refreshed;
+  }
   function buildProviderHeaders(config, format, includeContentType) {
     const normalizedFormat = normalizeFormat(format);
-    const headers =
-      normalizedFormat === ANTHROPIC_FORMAT
-        ? {
-            "x-api-key": config.apiKey,
-            "anthropic-version": "2023-06-01",
-            Accept: "application/json",
-          }
-        : {
-            Authorization: `Bearer ${config.apiKey}`,
-            Accept: "application/json",
-          };
+    let headers;
+    if (normalizedFormat === ANTHROPIC_FORMAT) {
+      headers = {
+        "x-api-key": config.apiKey,
+        "anthropic-version": "2023-06-01",
+        Accept: "application/json",
+      };
+    } else if (isCodexAuthConfig(config)) {
+      headers = {
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: "text/event-stream, application/json",
+        version: "claw-in-chrome-codex-provider",
+      };
+      if (config.codexAccountId) {
+        headers["ChatGPT-Account-ID"] = config.codexAccountId;
+      }
+    } else {
+      headers = {
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: "application/json",
+      };
+    }
     if (includeContentType) {
       headers["content-type"] = "application/json";
     }
@@ -986,6 +1386,9 @@
     );
   }
   function buildHealthCheckCandidates(config) {
+    if (isCodexAuthConfig(config)) {
+      return [OPENAI_RESPONSES_FORMAT];
+    }
     const requestedFormat = normalizeFormat(config?.format);
     const candidates = [requestedFormat];
     const baseUrl = String(config?.baseUrl || "")
@@ -1040,12 +1443,39 @@
         ],
       };
     }
-    return {
+    const responseBody = {
       model,
-      max_output_tokens: HEALTH_CHECK_MAX_TOKENS,
-      input: HEALTH_CHECK_PROMPT,
-      stream: false,
+      input: isCodexAuthConfig(config)
+        ? [
+            {
+              type: "message",
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: HEALTH_CHECK_PROMPT,
+                },
+              ],
+            },
+          ]
+        : HEALTH_CHECK_PROMPT,
+      ...(isCodexAuthConfig(config)
+        ? {
+            instructions: "",
+            tools: [],
+            tool_choice: "auto",
+            parallel_tool_calls: false,
+            reasoning: null,
+            store: false,
+            include: [],
+          }
+        : {}),
+      stream: isCodexAuthConfig(config),
     };
+    if (!isCodexAuthConfig(config)) {
+      responseBody.max_output_tokens = HEALTH_CHECK_MAX_TOKENS;
+    }
+    return responseBody;
   }
   function extractReadableTextFromPart(part, options) {
     const settings = options && typeof options === "object" ? options : {};
@@ -1268,7 +1698,7 @@
     try {
       const headers = buildProviderHeaders(next, next.format, false);
       const response = await (options?.fetchImpl || globalThis.fetch)(
-        joinUrl(next.baseUrl, "models"),
+        buildModelsUrl(next),
         {
           method: "GET",
           headers,
@@ -1281,15 +1711,26 @@
           extractErrorMessage(payload, `获取模型失败（${response.status}）`),
         );
       }
-      const list = Array.isArray(payload?.data) ? payload.data : [];
+      const list = Array.isArray(payload?.data)
+        ? payload.data
+        : Array.isArray(payload?.models)
+          ? payload.models
+          : [];
       const models = dedupeModels(
-        list.map(function (item) {
-          const id = String(item?.id || "").trim();
-          return {
-            value: id,
-            label: String(item?.display_name || id).trim() || id,
-          };
-        }),
+        list
+          .filter(function (item) {
+            if (!isCodexAuthConfig(next)) {
+              return true;
+            }
+            return item?.visibility !== "hide" && item?.supported_in_api !== false;
+          })
+          .map(function (item) {
+            const id = String(item?.id || item?.slug || "").trim();
+            return {
+              value: id,
+              label: String(item?.display_name || id).trim() || id,
+            };
+          }),
       );
       if (!models.length) {
         throw new Error("接口已响应，但没有返回可选模型。");
@@ -1333,7 +1774,7 @@
             body: JSON.stringify(buildHealthCheckBody(next, format)),
             signal: controller.signal,
           });
-          const payload = await parseJsonSafe(response);
+          const payload = await parseProviderPayload(response);
           if (!response.ok) {
             throw new Error(
               extractErrorMessage(
@@ -1400,6 +1841,10 @@
     OPENAI_CHAT_FORMAT,
     OPENAI_RESPONSES_FORMAT,
     DEFAULT_FORMAT,
+    AUTH_MODE_API_KEY,
+    AUTH_MODE_CODEX,
+    DEFAULT_AUTH_MODE,
+    CODEX_DEFAULT_BASE_URL,
     DEFAULT_CONTEXT_WINDOW,
     DEFAULT_MAX_OUTPUT_TOKENS,
     LEGACY_STORAGE_KEY,
@@ -1412,6 +1857,7 @@
     HTTP_PROVIDER_MIGRATED_KEY,
     HTTP_PROVIDER_DISABLED_MESSAGE,
     extractErrorMessage,
+    normalizeAuthMode,
     normalizeFormat,
     normalizeReasoningEffort,
     normalizeMaxOutputTokens,
@@ -1431,6 +1877,7 @@
     reconcileActiveProviderModelSelection,
     readCachedFetchedModels,
     persistFetchedModelsForConfig,
+    refreshCodexAuthForConfig,
     buildRequestUrl,
     fetchProviderModels,
     probeProviderModel,

--- a/custom-provider-settings.js
+++ b/custom-provider-settings.js
@@ -77,6 +77,8 @@
     "token",
     "secret",
     "password",
+    "codexrefreshtoken",
+    "codexaccesstoken",
     "currentapikey",
     "originalapikey",
   ]);
@@ -183,8 +185,11 @@
           ? value.contextWindow
           : value?.contextWindow || undefined,
       name: sanitizeDebugExportString(value?.name || "", "name"),
+      authMode: sanitizeDebugExportString(value?.authMode || "", "authMode"),
       fetchedModelCount: fetchedModels.length,
       hasApiKey: !!value?.apiKey,
+      hasCodexRefreshToken: !!value?.codexRefreshToken,
+      hasCodexAccountId: !!value?.codexAccountId,
       hasBaseUrl: !!value?.baseUrl,
     };
   }
@@ -265,11 +270,16 @@
       providerNameLabel: "Provider name",
       providerNamePlaceholder: "OpenRouter / Private gateway",
       providerFormatLabel: "Provider format",
+      authModeLabel: "Authentication",
+      authModeApiKey: "API key",
+      authModeCodex: "Codex login",
       baseUrlLabel: "Base URL",
       baseUrlPlaceholder: "https://api.openai.com/v1",
       requestUrlPrefix: "Request URL: ",
       apiKeyLabel: "API key",
       apiKeyPlaceholder: "provider key",
+      codexAuthLabel: "Codex auth JSON / access token",
+      codexAuthPlaceholder: "Paste ~/.codex/auth.json or a Codex access token",
       showApiKey: "Show API key",
       hideApiKey: "Hide API key",
       defaultModelLabel: "Model",
@@ -555,6 +565,13 @@
 
   const helpers = globalThis.CustomProviderModels || {};
   const DEFAULT_FORMAT = helpers.DEFAULT_FORMAT || "anthropic";
+  const AUTH_MODE_API_KEY = helpers.AUTH_MODE_API_KEY || "api_key";
+  const AUTH_MODE_CODEX = helpers.AUTH_MODE_CODEX || "codex";
+  const DEFAULT_AUTH_MODE = helpers.DEFAULT_AUTH_MODE || AUTH_MODE_API_KEY;
+  const CODEX_DEFAULT_BASE_URL =
+    helpers.CODEX_DEFAULT_BASE_URL || "https://chatgpt.com/backend-api/codex";
+  const OPENAI_RESPONSES_FORMAT =
+    helpers.OPENAI_RESPONSES_FORMAT || "openai_responses";
   const DEFAULT_CONTEXT_WINDOW = helpers.DEFAULT_CONTEXT_WINDOW || 200000;
   const DEFAULT_MAX_OUTPUT_TOKENS = helpers.DEFAULT_MAX_OUTPUT_TOKENS || 10000;
   const MIN_CONTEXT_WINDOW = 20000;
@@ -974,9 +991,13 @@
     function () {
       return {
         name: "",
+        authMode: DEFAULT_AUTH_MODE,
         format: DEFAULT_FORMAT,
         baseUrl: "",
         apiKey: "",
+        codexAccountId: "",
+        codexRefreshToken: "",
+        codexLastRefresh: "",
         defaultModel: "",
         fastModel: "",
         reasoningEffort: "medium",
@@ -1051,14 +1072,36 @@
     helpers.normalizeConfig ||
     function (raw, fallbackEnabled) {
       const source = raw && typeof raw === "object" ? raw : {};
+      const authMode =
+        String(source.authMode || "").trim().toLowerCase() === AUTH_MODE_CODEX
+          ? AUTH_MODE_CODEX
+          : DEFAULT_AUTH_MODE;
       return {
         name: String(source.name || "").trim(),
+        authMode,
         format:
-          String(source.format || DEFAULT_FORMAT).trim() || DEFAULT_FORMAT,
-        baseUrl: String(source.baseUrl || "")
+          authMode === AUTH_MODE_CODEX
+            ? OPENAI_RESPONSES_FORMAT
+            : String(source.format || DEFAULT_FORMAT).trim() || DEFAULT_FORMAT,
+        baseUrl: String(
+          source.baseUrl ||
+            (authMode === AUTH_MODE_CODEX ? CODEX_DEFAULT_BASE_URL : ""),
+        )
           .trim()
           .replace(/\/+$/, ""),
         apiKey: String(source.apiKey || "").trim(),
+        codexAccountId:
+          authMode === AUTH_MODE_CODEX
+            ? String(source.codexAccountId || "").trim()
+            : "",
+        codexRefreshToken:
+          authMode === AUTH_MODE_CODEX
+            ? String(source.codexRefreshToken || "").trim()
+            : "",
+        codexLastRefresh:
+          authMode === AUTH_MODE_CODEX
+            ? String(source.codexLastRefresh || "").trim()
+            : "",
         defaultModel: String(source.defaultModel || "").trim(),
         fastModel: String(
           source.fastModel || source.small_fast_model || "",
@@ -3541,6 +3584,10 @@
       ["openai_chat", "OpenAI Chat Completions"],
       ["openai_responses", "OpenAI Responses API"],
     ];
+    const providerAuthModeOptions = [
+      [AUTH_MODE_API_KEY, strings.authModeApiKey],
+      [AUTH_MODE_CODEX, strings.authModeCodex],
+    ];
     const identityGrid = createNode("div", "cp-page-grid cp-page-grid-2");
     const nameField = createNode("label", "cp-page-field");
     const nameInput = createNode(
@@ -3567,8 +3614,24 @@
       createNode("span", "cp-page-label", strings.providerFormatLabel),
     );
     formatField.appendChild(formatSelect);
+    const authModeField = createNode("label", "cp-page-field");
+    const authModeSelect = createNode(
+      "select",
+      `cp-page-select ${SHARED_FRAME_CLASS}`,
+    );
+    providerAuthModeOptions.forEach(function (option) {
+      const node = document.createElement("option");
+      node.value = option[0];
+      node.textContent = option[1];
+      authModeSelect.appendChild(node);
+    });
+    authModeField.appendChild(
+      createNode("span", "cp-page-label", strings.authModeLabel),
+    );
+    authModeField.appendChild(authModeSelect);
     identityGrid.appendChild(nameField);
     identityGrid.appendChild(formatField);
+    identityGrid.appendChild(authModeField);
     const baseUrlField = createNode("label", "cp-page-field");
     const baseUrlInput = createNode(
       "input",
@@ -3611,9 +3674,8 @@
         preventScroll: true,
       });
     });
-    apiKeyField.appendChild(
-      createNode("span", "cp-page-label", strings.apiKeyLabel),
-    );
+    const apiKeyLabel = createNode("span", "cp-page-label", strings.apiKeyLabel);
+    apiKeyField.appendChild(apiKeyLabel);
     apiKeyShell.appendChild(apiKeyInput);
     apiKeyShell.appendChild(apiKeyToggle);
     apiKeyField.appendChild(apiKeyShell);
@@ -4506,6 +4568,7 @@
       isLoadingSnapshot: false,
     };
     const formatDropdown = enhanceSelect(formatSelect);
+    const authModeDropdown = enhanceSelect(authModeSelect);
     const modelDropdown = enhanceSelect(modelSelect);
     const fastModelDropdown = enhanceSelect(fastModelSelect);
     const reasoningDropdown = enhanceSelect(reasoningSelect);
@@ -4600,10 +4663,15 @@
     }
     function getProviderFetchIdentity(config) {
       const next = normalizeConfig(config, false);
+      const credentialKey =
+        next.authMode === AUTH_MODE_CODEX
+          ? next.codexAccountId || next.codexRefreshToken || next.apiKey
+          : next.apiKey;
       return [
+        next.authMode || DEFAULT_AUTH_MODE,
         next.format || DEFAULT_FORMAT,
         String(next.baseUrl || "").trim(),
-        String(next.apiKey || "").trim(),
+        String(credentialKey || "").trim(),
       ].join("::");
     }
     let cachedModelsHydrationToken = 0;
@@ -4613,7 +4681,7 @@
       fastSelectedValue,
     ) {
       const identity = getProviderFetchIdentity(config);
-      if (!identity || identity === `${DEFAULT_FORMAT}:::`) {
+      if (!identity || identity === `${DEFAULT_AUTH_MODE}::${DEFAULT_FORMAT}:::`) {
         return;
       }
       const token = ++cachedModelsHydrationToken;
@@ -7052,10 +7120,30 @@
         ? "false"
         : "true";
     }
+    function syncAuthModeUi(fillDefaults) {
+      const isCodex = authModeSelect.value === AUTH_MODE_CODEX;
+      apiKeyLabel.textContent = isCodex
+        ? strings.codexAuthLabel
+        : strings.apiKeyLabel;
+      apiKeyInput.placeholder = isCodex
+        ? strings.codexAuthPlaceholder
+        : strings.apiKeyPlaceholder;
+      if (isCodex) {
+        if (fillDefaults && !baseUrlInput.value.trim()) {
+          baseUrlInput.value = CODEX_DEFAULT_BASE_URL;
+        }
+        if (formatSelect.value !== OPENAI_RESPONSES_FORMAT) {
+          formatSelect.value = OPENAI_RESPONSES_FORMAT;
+          formatDropdown.refresh();
+        }
+      }
+      updateRequestPreview();
+    }
     function readForm() {
       const next = normalizeConfig(
         {
           name: nameInput.value,
+          authMode: authModeSelect.value,
           format: formatSelect.value,
           baseUrl: baseUrlInput.value,
           apiKey: apiKeyInput.value,
@@ -7076,10 +7164,13 @@
     function writeForm(config) {
       const next = normalizeConfig(config, false);
       nameInput.value = next.name || "";
+      authModeSelect.value = next.authMode || DEFAULT_AUTH_MODE;
       formatSelect.value = next.format || DEFAULT_FORMAT;
       baseUrlInput.value = next.baseUrl || "";
       apiKeyInput.value = next.apiKey || "";
+      authModeDropdown.refresh();
       formatDropdown.refresh();
+      syncAuthModeUi(false);
       syncReasoningEditorControls(
         next.reasoningEffort || "medium",
         next.contextWindow,
@@ -7687,7 +7778,7 @@
         preventScroll: true,
       });
     });
-    [formatSelect, baseUrlInput, apiKeyInput].forEach(function (node) {
+    [authModeSelect, formatSelect, baseUrlInput, apiKeyInput].forEach(function (node) {
       node.addEventListener("change", clearModels);
       node.addEventListener("input", function () {
         if (state.availableModels.length) {
@@ -7702,6 +7793,12 @@
           function () {},
         );
       });
+    });
+    authModeSelect.addEventListener("change", function () {
+      syncAuthModeUi(true);
+      hydrateCachedModelsForConfig(readForm(), modelSelect.value || "").catch(
+        function () {},
+      );
     });
     [formatSelect, baseUrlInput].forEach(function (node) {
       node.addEventListener("change", updateRequestPreview);

--- a/provider-format-adapter.js
+++ b/provider-format-adapter.js
@@ -10,6 +10,8 @@
   const NATIVE_FETCH_KEY = "__customProviderNativeFetch__";
   const OPENAI_CHAT_FORMAT = "openai_chat";
   const OPENAI_RESPONSES_FORMAT = "openai_responses";
+  const AUTH_MODE_API_KEY = "api_key";
+  const AUTH_MODE_CODEX = "codex";
   const DEFAULT_CONTEXT_WINDOW = 200000;
   const DEFAULT_MAX_OUTPUT_TOKENS = 10000;
   const MIN_CONTEXT_WINDOW = 20000;
@@ -93,6 +95,19 @@
     }
     return ANTHROPIC_FORMAT;
   }
+  function normalizeAuthMode(value) {
+    const helpers = getProviderStoreHelpers();
+    if (helpers && typeof helpers.normalizeAuthMode === "function") {
+      return helpers.normalizeAuthMode(value);
+    }
+    const mode = String(value || "").trim().toLowerCase();
+    return mode === AUTH_MODE_CODEX || mode === "chatgpt"
+      ? AUTH_MODE_CODEX
+      : AUTH_MODE_API_KEY;
+  }
+  function isCodexAuthConfig(config) {
+    return normalizeAuthMode(config?.authMode) === AUTH_MODE_CODEX;
+  }
   function inferFormat(source) {
     const explicitFormat = String(source?.format || "").trim();
     if (explicitFormat) {
@@ -143,14 +158,38 @@
     return Math.max(1, Math.round(numeric));
   }
   function normalizeConfig(raw) {
-    const source = raw && typeof raw === "object" ? raw : {};
+    const original = raw && typeof raw === "object" ? raw : {};
+    const helpers = getProviderStoreHelpers();
+    const source =
+      helpers && typeof helpers.normalizeConfig === "function"
+        ? {
+            ...original,
+            ...helpers.normalizeConfig(original)
+          }
+        : original;
+    const authMode = normalizeAuthMode(source.authMode);
     return {
+      id: String(source.id || source.profileId || "").trim(),
       name: String(source.name || "").trim(),
       baseUrl: String(source.baseUrl || "").trim().replace(/\/+$/, ""),
       apiKey: String(source.apiKey || "").trim(),
+      authMode,
+      codexAccountId:
+        authMode === AUTH_MODE_CODEX
+          ? String(source.codexAccountId || source.accountId || "").trim()
+          : "",
+      codexRefreshToken:
+        authMode === AUTH_MODE_CODEX
+          ? String(source.codexRefreshToken || source.refreshToken || "").trim()
+          : "",
+      codexLastRefresh:
+        authMode === AUTH_MODE_CODEX
+          ? String(source.codexLastRefresh || source.lastRefresh || "").trim()
+          : "",
       defaultModel: String(source.defaultModel || "").trim(),
       fastModel: String(source.fastModel || source.small_fast_model || "").trim(),
-      format: inferFormat(source),
+      format:
+        authMode === AUTH_MODE_CODEX ? OPENAI_RESPONSES_FORMAT : inferFormat(source),
       reasoningEffort: normalizeReasoningEffort(source.reasoningEffort),
       maxOutputTokens: normalizeMaxOutputTokens(source.maxOutputTokens),
       contextWindow: normalizeContextWindow(source.contextWindow),
@@ -173,7 +212,7 @@
       ...body
     };
     const hasExplicitMaxTokens = Number.isFinite(Number(body?.max_tokens)) && Number(body.max_tokens) > 0;
-    if (!hasExplicitMaxTokens && Number.isFinite(Number(config?.maxOutputTokens)) && Number(config.maxOutputTokens) > 0) {
+    if (!isCodexAuthConfig(config) && !hasExplicitMaxTokens && Number.isFinite(Number(config?.maxOutputTokens)) && Number(config.maxOutputTokens) > 0) {
       nextBody.max_tokens = Number(config.maxOutputTokens);
     }
     const hasExplicitReasoningConfig = body?.output_config && typeof body.output_config === "object" && String(body.output_config.effort || "").trim() || body?.thinking && typeof body.thinking === "object";
@@ -220,6 +259,34 @@
       return cachedConfig;
     }
     return readConfig();
+  }
+  async function resolveProviderRequestConfig(config, options) {
+    const next = normalizeConfig(config);
+    if (!isCodexAuthConfig(next)) {
+      return next;
+    }
+    const helpers = getProviderStoreHelpers();
+    if (!helpers || typeof helpers.refreshCodexAuthForConfig !== "function") {
+      return next;
+    }
+    try {
+      const refreshed = normalizeConfig(
+        await helpers.refreshCodexAuthForConfig(next, {
+          profileId: next.id,
+          fetchImpl: nativeFetch,
+          force: !!options?.force,
+          signal: options?.signal
+        })
+      );
+      cachedConfig = refreshed;
+      hasLoadedConfig = true;
+      return refreshed;
+    } catch (error) {
+      debugLog("provider.codex_refresh_failed", {
+        message: String(error?.message || error || "")
+      }, "warn");
+      return next;
+    }
   }
   if (globalThis.chrome?.storage?.onChanged) {
     chrome.storage.onChanged.addListener(function (changes, areaName) {
@@ -1017,6 +1084,12 @@
     }
   }
   function buildProviderRequestCandidates(config, body) {
+    if (isCodexAuthConfig(config)) {
+      return [{
+        format: OPENAI_RESPONSES_FORMAT,
+        reason: "codex_auth"
+      }];
+    }
     const requestedFormat = normalizeFormat(config?.format);
     const candidates = [{
       format: requestedFormat,
@@ -1828,7 +1901,8 @@
     }
     return input;
   }
-  function anthropicToOpenAIResponses(body, promptCacheKey) {
+  function anthropicToOpenAIResponses(body, promptCacheKey, config) {
+    const codexAuth = isCodexAuthConfig(config);
     const result = {};
     if (body?.model) {
       result.model = body.model;
@@ -1840,17 +1914,23 @@
     if (Array.isArray(body?.messages)) {
       result.input = convertMessagesToResponsesInput(body.messages);
     }
-    if (body?.max_tokens != null) {
+    if (!codexAuth && body?.max_tokens != null) {
       result.max_output_tokens = body.max_tokens;
     }
-    if (body?.temperature != null) {
+    if (!codexAuth && body?.temperature != null) {
       result.temperature = body.temperature;
     }
-    if (body?.top_p != null) {
+    if (!codexAuth && body?.top_p != null) {
       result.top_p = body.top_p;
     }
     if (body?.stream != null) {
       result.stream = body.stream;
+    }
+    if (codexAuth) {
+      if (typeof result.instructions !== "string") {
+        result.instructions = "";
+      }
+      result.store = false;
     }
     const effort = resolveReasoningEffort(body);
     if (effort) {
@@ -2860,6 +2940,12 @@
     }
     headers.set("content-type", "application/json");
     headers.set("authorization", "Bearer " + config.apiKey);
+    if (isCodexAuthConfig(config)) {
+      headers.set("version", "claw-in-chrome-codex-provider");
+      if (config.codexAccountId) {
+        headers.set("ChatGPT-Account-ID", config.codexAccountId);
+      }
+    }
     if (isStreamRequest) {
       headers.set("accept", "text/event-stream");
     }
@@ -2918,31 +3004,34 @@
     return createAnthropicErrorResponse(parsed.status, parsed.message);
   }
   async function forwardProviderRequest(request, config) {
-    await assertHttpProviderAllowed(config);
+    const requestConfig = await resolveProviderRequestConfig(config, {
+      signal: request.signal
+    });
+    await assertHttpProviderAllowed(requestConfig);
     const bodyText = await request.clone().text();
     const parsedBody = safeJsonParse(bodyText, null);
-    const body = applyConfiguredAnthropicDefaults(parsedBody, config);
+    const body = applyConfiguredAnthropicDefaults(parsedBody, requestConfig);
     if (!body || typeof body !== "object") {
       return createAnthropicErrorResponse(400, "自定义供应商只支持 JSON 请求体。");
     }
-    const candidates = buildProviderRequestCandidates(config, body);
+    const candidates = buildProviderRequestCandidates(requestConfig, body);
     debugLog("provider.request_start", {
-      configuredFormat: config.format,
+      configuredFormat: requestConfig.format,
       candidateFormats: candidates.map(function (item) {
         return item.format;
       }),
-      baseUrl: config.baseUrl,
+      baseUrl: requestConfig.baseUrl,
       model: String(body?.model || ""),
       stream: !!body?.stream,
       messageCount: Array.isArray(body?.messages) ? body.messages.length : 0
     });
     for (let index = 0; index < candidates.length; index++) {
       const candidate = candidates[index];
-      const candidateConfig = {
-        ...config,
+      let candidateConfig = {
+        ...requestConfig,
         format: candidate.format
       };
-      const providerBody = candidate.format === OPENAI_CHAT_FORMAT ? anthropicToOpenAIChat(body, candidateConfig.promptCacheKey) : anthropicToOpenAIResponses(body, candidateConfig.promptCacheKey);
+      const providerBody = candidate.format === OPENAI_CHAT_FORMAT ? anthropicToOpenAIChat(body, candidateConfig.promptCacheKey) : anthropicToOpenAIResponses(body, candidateConfig.promptCacheKey, candidateConfig);
       const providerUrl = buildProviderUrl(candidateConfig);
       const isStreamRequest = !!providerBody.stream;
       debugLog("provider.request_attempt", {
@@ -2965,6 +3054,25 @@
         if (!upstream.ok) {
           const providerError = await parseProviderError(upstream, "自定义模型供应商返回了错误。");
           lastProviderError = providerError;
+          if (isCodexAuthConfig(candidateConfig) && providerError.status === 401 && retryIndex === 0) {
+            const refreshedConfig = await resolveProviderRequestConfig(candidateConfig, {
+              force: true,
+              signal: request.signal
+            });
+            if (refreshedConfig.apiKey && refreshedConfig.apiKey !== candidateConfig.apiKey) {
+              candidateConfig = {
+                ...refreshedConfig,
+                format: candidate.format
+              };
+              debugLog("provider.codex_refresh_retry", {
+                attempt: index + 1,
+                totalAttempts: candidates.length,
+                format: candidate.format,
+                providerUrl
+              }, "warn");
+              continue;
+            }
+          }
           const detectedLimit = extractMaxTokenLimit(providerError.message) || extractMaxTokenLimit(providerError.text);
           const appliedClamp = detectedLimit != null ? clampRequestMaxTokens(providerBody, detectedLimit) : null;
           if (appliedClamp) {
@@ -2976,7 +3084,7 @@
               reason: candidate.reason,
               providerUrl,
               status: providerError.status,
-              model: String(providerBody?.model || body?.model || config?.defaultModel || ""),
+              model: String(providerBody?.model || body?.model || requestConfig?.defaultModel || ""),
               tokenKey: appliedClamp.key,
               previousMaxTokens: appliedClamp.previous,
               cappedMaxTokens: appliedClamp.next,
@@ -3010,7 +3118,12 @@
           contentType,
           stream: isStreamRequest
         });
-        if (isStreamRequest && contentType.includes("text/event-stream") && upstream.body) {
+        const isEventStreamResponse =
+          contentType.includes("text/event-stream") ||
+          (isCodexAuthConfig(candidateConfig) &&
+            upstream.body &&
+            !contentType.includes("application/json"));
+        if (isStreamRequest && isEventStreamResponse && upstream.body) {
           debugLog("provider.stream_transform", {
             attempt: index + 1,
             totalAttempts: candidates.length,

--- a/tests/unit/custom-provider-models.sync-regression.test.js
+++ b/tests/unit/custom-provider-models.sync-regression.test.js
@@ -565,6 +565,219 @@ async function testLegacyActiveHttpProfileMigratesToggleToEnabled() {
   assert.equal(storageArea.state.customProviderAllowHttpMigrated, true);
 }
 
+async function testCodexAuthJsonNormalizesAndSavesTokens() {
+  const authJson = JSON.stringify({
+    tokens: {
+      access_token: "codex-access",
+      refresh_token: "codex-refresh",
+      account_id: "acc_123"
+    },
+    last_refresh: "2026-04-25T00:00:00.000Z"
+  });
+  const storageArea = createStorageArea({});
+  const models = loadModels(storageArea);
+  await waitForMicrotasks();
+
+  const normalized = models.normalizeConfig({
+    authMode: models.AUTH_MODE_CODEX,
+    apiKey: authJson,
+    defaultModel: "gpt-5.5"
+  });
+
+  assert.equal(normalized.authMode, models.AUTH_MODE_CODEX);
+  assert.equal(normalized.format, models.OPENAI_RESPONSES_FORMAT);
+  assert.equal(normalized.baseUrl, models.CODEX_DEFAULT_BASE_URL);
+  assert.equal(normalized.apiKey, "codex-access");
+  assert.equal(normalized.codexRefreshToken, "codex-refresh");
+  assert.equal(normalized.codexAccountId, "acc_123");
+
+  await models.saveProviderProfile({
+    ...createProfile({
+      authMode: models.AUTH_MODE_CODEX,
+      format: models.OPENAI_RESPONSES_FORMAT,
+      baseUrl: "",
+      apiKey: authJson,
+      defaultModel: "gpt-5.5"
+    })
+  }, {
+    profileId: "provider_codex",
+    storageArea
+  });
+
+  assert.equal(storageArea.state.customProviderProfiles[0].apiKey, "codex-access");
+  assert.equal(storageArea.state.customProviderProfiles[0].codexRefreshToken, "codex-refresh");
+  assert.equal(storageArea.state.customProviderProfiles[0].codexAccountId, "acc_123");
+  assert.equal(storageArea.state.customProviderConfig.baseUrl, models.CODEX_DEFAULT_BASE_URL);
+}
+
+async function testCodexProbeUsesStreamingResponsesAndAccountHeader() {
+  const storageArea = createStorageArea({});
+  const models = loadModels(storageArea);
+  await waitForMicrotasks();
+  let capturedCall = null;
+  const fetchImpl = async (input, init) => {
+    capturedCall = {
+      url: String(input),
+      headers: init.headers,
+      body: JSON.parse(init.body)
+    };
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get() {
+          return "text/event-stream";
+        }
+      },
+      async text() {
+        return [
+          "event: response.output_text.delta",
+          "data: {\"type\":\"response.output_text.delta\",\"delta\":\"OK\"}",
+          "",
+          "data: [DONE]",
+          ""
+        ].join("\n");
+      }
+    };
+  };
+
+  const result = await models.probeProviderModel(createProfile({
+    authMode: models.AUTH_MODE_CODEX,
+    format: models.OPENAI_RESPONSES_FORMAT,
+    baseUrl: models.CODEX_DEFAULT_BASE_URL,
+    apiKey: "codex-access",
+    codexAccountId: "acc_123",
+    defaultModel: "gpt-5.5"
+  }), {
+    storageArea,
+    fetchImpl
+  });
+
+  assert.equal(capturedCall.url, `${models.CODEX_DEFAULT_BASE_URL}/responses`);
+  assert.equal(capturedCall.headers.Authorization, "Bearer codex-access");
+  assert.equal(capturedCall.headers["ChatGPT-Account-ID"], "acc_123");
+  assert.equal(capturedCall.headers.Accept, "text/event-stream, application/json");
+  assert.equal(capturedCall.body.stream, true);
+  assert.equal(Object.prototype.hasOwnProperty.call(capturedCall.body, "max_output_tokens"), false);
+  assert.equal(Array.isArray(capturedCall.body.input), true);
+  assert.equal(result.replyText, "OK");
+  assert.equal(result.ok, true);
+}
+
+async function testCodexFetchModelsUsesClientVersionAndModelsPayload() {
+  const storageArea = createStorageArea({});
+  const models = loadModels(storageArea);
+  await waitForMicrotasks();
+  let capturedCall = null;
+  const fetchImpl = async (input, init) => {
+    capturedCall = {
+      url: String(input),
+      headers: init.headers
+    };
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get() {
+          return "application/json";
+        }
+      },
+      async text() {
+        return JSON.stringify({
+          models: [
+            {
+              slug: "gpt-5.5",
+              display_name: "GPT-5.5",
+              visibility: "list",
+              supported_in_api: true
+            },
+            {
+              slug: "gpt-hidden",
+              display_name: "Hidden",
+              visibility: "hide",
+              supported_in_api: true
+            },
+            {
+              slug: "gpt-unsupported",
+              display_name: "Unsupported",
+              visibility: "list",
+              supported_in_api: false
+            }
+          ]
+        });
+      }
+    };
+  };
+
+  const fetched = await models.fetchProviderModels(createProfile({
+    authMode: models.AUTH_MODE_CODEX,
+    format: models.OPENAI_RESPONSES_FORMAT,
+    baseUrl: models.CODEX_DEFAULT_BASE_URL,
+    apiKey: "codex-access",
+    codexAccountId: "acc_123",
+    defaultModel: "gpt-5.5"
+  }), {
+    storageArea,
+    fetchImpl
+  });
+
+  assert.match(capturedCall.url, /\/models\?client_version=0\.125\.0-alpha\.3$/);
+  assert.equal(capturedCall.headers.Authorization, "Bearer codex-access");
+  assert.equal(capturedCall.headers["ChatGPT-Account-ID"], "acc_123");
+  assert.equal(fetched.length, 1);
+  assert.equal(fetched[0].value, "gpt-5.5");
+  assert.equal(fetched[0].label, "GPT-5.5");
+  assert.equal(fetched[0].manual, false);
+}
+
+async function testCodexRefreshPersistsUpdatedTokens() {
+  const codexProfile = createProfile({
+    authMode: "codex",
+    format: "openai_responses",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    apiKey: "old-access",
+    codexRefreshToken: "old-refresh",
+    codexAccountId: "acc_123",
+    defaultModel: "gpt-5.5"
+  });
+  const storageArea = createStorageArea({
+    customProviderProfiles: [codexProfile],
+    customProviderActiveProfileId: codexProfile.id,
+    customProviderConfig: projectProfileToConfig(codexProfile)
+  });
+  const models = loadModels(storageArea);
+  await waitForMicrotasks();
+  let refreshBody = null;
+  const fetchImpl = async (input, init) => {
+    assert.equal(String(input), "https://auth.openai.com/oauth/token");
+    refreshBody = JSON.parse(init.body);
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "new-refresh"
+        });
+      }
+    };
+  };
+
+  const refreshed = await models.refreshCodexAuthForConfig(codexProfile, {
+    profileId: codexProfile.id,
+    storageArea,
+    fetchImpl,
+    force: true
+  });
+
+  assert.equal(refreshBody.grant_type, "refresh_token");
+  assert.equal(refreshBody.refresh_token, "old-refresh");
+  assert.equal(refreshed.apiKey, "new-access");
+  assert.equal(refreshed.codexRefreshToken, "new-refresh");
+  assert.equal(storageArea.state.customProviderProfiles[0].apiKey, "new-access");
+  assert.equal(storageArea.state.customProviderConfig.apiKey, "new-access");
+}
+
 async function main() {
   await testSavingActiveProfileSyncsSelectedModels();
   await testSavingNonModelFieldsKeepsExistingStickySelection();
@@ -580,6 +793,10 @@ async function main() {
   await testFetchAndProbeAllowHttpByDefault();
   await testFetchAndProbeRejectWhenHttpExplicitlyDisabled();
   await testLegacyActiveHttpProfileMigratesToggleToEnabled();
+  await testCodexAuthJsonNormalizesAndSavesTokens();
+  await testCodexProbeUsesStreamingResponsesAndAccountHeader();
+  await testCodexFetchModelsUsesClientVersionAndModelsPayload();
+  await testCodexRefreshPersistsUpdatedTokens();
   console.log("custom-provider-models sync regression tests passed");
 }
 

--- a/tests/unit/provider-format-adapter.find-regression.test.js
+++ b/tests/unit/provider-format-adapter.find-regression.test.js
@@ -85,7 +85,7 @@ async function runAdapterWithUpstreamHandler(upstreamHandler, options = {}) {
       }
     ]
   };
-  const request = new Request("https://provider.example/v1/messages", {
+  const request = new Request(options.requestUrl || "https://provider.example/v1/messages", {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -95,6 +95,13 @@ async function runAdapterWithUpstreamHandler(upstreamHandler, options = {}) {
     body: JSON.stringify(requestBody)
   });
   const response = await sandbox.fetch(request);
+  if (options.readText) {
+    return {
+      status: response.status,
+      text: await response.text(),
+      upstreamCalls
+    };
+  }
   return {
     status: response.status,
     json: await response.json(),
@@ -375,6 +382,113 @@ async function testResponsesTextWrappedToolCallIsConvertedToToolUse() {
     }
   ]);
   assert.equal(result.json.stop_reason, "tool_use");
+}
+
+async function testCodexAuthHeadersForwardToResponsesEndpoint() {
+  const result = await runAdapterWithUpstreamHandler(async () => new Response(JSON.stringify({
+    id: "resp-codex",
+    model: "gpt-5.5",
+    status: "completed",
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "output_text",
+            text: "FOUND: 0\nERROR: no matches"
+          }
+        ]
+      }
+    ]
+  }), {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8"
+    }
+  }), {
+    config: {
+      authMode: "codex",
+      format: "openai_responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      apiKey: "codex-access",
+      codexAccountId: "acc_123",
+      defaultModel: "gpt-5.5"
+    },
+    requestUrl: "https://chatgpt.com/backend-api/codex/messages",
+    requestBody: {
+      model: "gpt-5.5",
+      max_tokens: 128,
+      temperature: 0,
+      stream: true,
+      messages: [
+        {
+          role: "user",
+          content: "Find cats"
+        }
+      ]
+    }
+  });
+
+  assert.equal(result.upstreamCalls.length, 1, "should call Codex once");
+  assert.equal(result.upstreamCalls[0].url, "https://chatgpt.com/backend-api/codex/responses");
+  assert.equal(result.upstreamCalls[0].headers.authorization, "Bearer codex-access");
+  assert.equal(result.upstreamCalls[0].headers["chatgpt-account-id"], "acc_123");
+  assert.equal(result.upstreamCalls[0].headers.version, "claw-in-chrome-codex-provider");
+  assert.equal(Object.prototype.hasOwnProperty.call(result.upstreamCalls[0].body, "max_output_tokens"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(result.upstreamCalls[0].body, "temperature"), false);
+  assert.equal(result.upstreamCalls[0].body.instructions, "");
+  assert.equal(result.upstreamCalls[0].body.store, false);
+  assert.equal(result.upstreamCalls[0].body.stream, true);
+  assert.equal(result.json.content[0].text, "FOUND: 0\nERROR: no matches");
+}
+
+async function testCodexStreamWithoutContentTypeTransforms() {
+  const result = await runAdapterWithUpstreamHandler(async () => new Response([
+    "event: response.created",
+    "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_codex_stream\",\"model\":\"gpt-5.5\",\"status\":\"in_progress\"}}",
+    "",
+    "event: response.output_text.delta",
+    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"OK\"}",
+    "",
+    "event: response.completed",
+    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_codex_stream\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"usage\":{\"input_tokens\":4,\"output_tokens\":1}}}",
+    "",
+    "data: [DONE]",
+    ""
+  ].join("\n"), {
+    status: 200
+  }), {
+    readText: true,
+    config: {
+      authMode: "codex",
+      format: "openai_responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      apiKey: "codex-access",
+      codexAccountId: "acc_123",
+      defaultModel: "gpt-5.5"
+    },
+    requestUrl: "https://chatgpt.com/backend-api/codex/messages",
+    requestBody: {
+      model: "gpt-5.5",
+      max_tokens: 128,
+      temperature: 0,
+      stream: true,
+      messages: [
+        {
+          role: "user",
+          content: "Find cats"
+        }
+      ]
+    }
+  });
+
+  assert.equal(result.status, 200);
+  assert.match(result.text, /event: message_start/);
+  assert.match(result.text, /event: content_block_delta/);
+  assert.match(result.text, /OK/);
+  assert.equal(Object.prototype.hasOwnProperty.call(result.upstreamCalls[0].body, "max_output_tokens"), false);
+  assert.equal(result.upstreamCalls[0].body.instructions, "");
+  assert.equal(result.upstreamCalls[0].body.store, false);
 }
 
 async function testResponsesRuntimeFallsBackToChatWhenConfiguredEndpointFails() {
@@ -890,6 +1004,8 @@ async function main() {
   await testJsonContentToolCallIsConvertedToToolUse();
   await testNestedFunctionWrapperContentIsConvertedToToolUse();
   await testResponsesTextWrappedToolCallIsConvertedToToolUse();
+  await testCodexAuthHeadersForwardToResponsesEndpoint();
+  await testCodexStreamWithoutContentTypeTransforms();
   await testResponsesRuntimeFallsBackToChatWhenConfiguredEndpointFails();
   await testGpt54ChatToolCallsDropReasoningEffort();
   await testConfiguredProviderDefaultsFillMissingAnthropicFields();

--- a/tests/unit/sidepanel-group-title-generation.regression.test.js
+++ b/tests/unit/sidepanel-group-title-generation.regression.test.js
@@ -21,13 +21,13 @@ function main() {
 
   assertIncludes(
     source,
-    "Think about it, then suggest a title based on the first message, putting it between <title> tags.",
+    "const r = __cpBuildTaskStyleGroupTitlePrompt(s, n);",
     "group title generator"
   );
 
   assertIncludes(
     source,
-    "Here is a clear, concise title for this browser automation conversation:\\n\\n<title>",
+    "Think like PageAgent naming an active browser task. Use the user's request as the main signal, then use page context only to make the title more specific. Put the final answer between <title> tags.",
     "group title generator"
   );
 
@@ -45,7 +45,13 @@ function main() {
 
   assertIncludes(
     source,
-    "return i ? t(i[1]) : t(n);",
+    "return o || __cpBuildTaskStyleGroupTitleFallback(s, n);",
+    "group title generator"
+  );
+
+  assertIncludes(
+    source,
+    "return __cpBuildTaskStyleGroupTitleFallback(s, n);",
     "group title generator"
   );
 
@@ -57,7 +63,7 @@ function main() {
 
   assertNotIncludes(
     source,
-    "Here is a concise task-style title for this browser tab group:\\n\\n<title>",
+    "Think about it, then suggest a title based on the first message, putting it between <title> tags.",
     "group title generator"
   );
 


### PR DESCRIPTION
## 概要
- 新增 `Codex login` 认证模式，用于自定义模型提供方 profile。
- 支持粘贴 `~/.codex/auth.json`，解析并保存 access token、refresh token、account id，并在需要时刷新 Codex access token。
- Codex 模式下通过 `/models?client_version=0.125.0-alpha.3` 获取模型列表，解析 Codex 的 `{ models: [...] }` 返回结构，并过滤隐藏或不支持 API 的模型。
- Codex profile 会走 `https://chatgpt.com/backend-api/codex`，带上 `ChatGPT-Account-ID`，使用 Codex 兼容的 Responses streaming 请求结构，并兼容后端缺少 `content-type` 的 SSE 返回。
- 在中英文 README 中补充 Codex 配置说明。

## 验证
- `node tests/unit/custom-provider-models.sync-regression.test.js`
- `node tests/unit/provider-format-adapter.find-regression.test.js`
- `npm run check:release-package`
- 使用本机 `~/.codex/auth.json` 真实测试 Codex 模型列表：成功获取 5 个可见且支持的模型，包含 `gpt-5.5`、`gpt-5.4`、`gpt-5.4-mini`、`gpt-5.3-codex`、`gpt-5.2`。
- 使用本机 `~/.codex/auth.json` 真实测试 Codex 健康检测：`ok=true`，请求端点为 `https://chatgpt.com/backend-api/codex/responses`。
- 使用真实 Codex 后端测试 adapter 转换：返回 Anthropic SSE，`status=200`，`hasAnthropicDelta=true`。

## 已知基线失败
- `npm run test:node` 仍会在 `unit/deobfuscation-anchors.regression.test.js` 失败，因为当前 service-worker bundle 中缺少测试期望的 native messaging anchor：`const __cpNativeMessagingContract = globalThis.__CP_CONTRACT__?.nativeMessaging || {};`。这个失败看起来与本 PR 修改的 provider 路径无关。
